### PR TITLE
[BUGFIX] Use SaltFactory for TYPO3 versions older than 9.4

### DIFF
--- a/Classes/Controller/ProtectPagesController.php
+++ b/Classes/Controller/ProtectPagesController.php
@@ -82,6 +82,12 @@ class ProtectPagesController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionCon
             }
         } else {
             if (version_compare(TYPO3_branch, '9.4', '<')) {
+                if (\TYPO3\CMS\Saltedpasswords\Utility\SaltedPasswordsUtility::isUsageEnabled('FE')) {
+                    $objSalt = \TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::getSaltingInstance(NULL);
+                    if (is_object($objSalt)) {
+                        $saltedPassword = $objSalt->getHashedPassword($saltedPassword);
+                    }
+                }
                 $objSalt = \TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::getSaltingInstance($saltedPassword, 'BE');
             } else {
                 $objSalt = (new \TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory)->get($saltedPassword, 'BE');

--- a/Classes/Controller/ProtectPagesController.php
+++ b/Classes/Controller/ProtectPagesController.php
@@ -81,7 +81,11 @@ class ProtectPagesController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionCon
                 $success = true;
             }
         } else {
-            $objSalt = (new \TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory)->get($saltedPassword, 'BE');
+            if (version_compare(TYPO3_branch, '9.4', '<')) {
+                $objSalt = \TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::getSaltingInstance($saltedPassword, 'BE');
+            } else {
+                $objSalt = (new \TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory)->get($saltedPassword, 'BE');
+            }
             if (is_object($objSalt)) {
                 $success = $objSalt->checkPassword($pass, $saltedPassword);
             }


### PR DESCRIPTION
TYPO3 merged `EXT:saltedpasswords` into core in version 9.4 (see https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Deprecation-85833-ExtensionSaltedpasswordsMergedIntoCoreExtension.html), renaming the `SaltFactory` class to ´PasswordHashFactory` in the process. The latter class is currently used for all versions. \
This commit changes the class used for older versions, especially 8.7, to be the old `SaltFactory`.

Resolves: #5